### PR TITLE
Fix improving subject

### DIFF
--- a/src/chrome/content/join.js
+++ b/src/chrome/content/join.js
@@ -336,7 +336,7 @@ var Join = {
 			sTbHead = this.GenerateOldOEHeader(sFirstMsgUri);
 
 		// Try to improve subject by removing [1/99] ant the end of it
-		sTbHead = sTbHead.replace(/(^Subject: .*)\s*\[\d+\/\d+\]$/m, "$1");
+		sTbHead = sTbHead.replace(/(^Subject: [\s\S]*)\s*\[\d+\/\d+\]$/m, "$1");
 
 		// X-Account-Key
 		if (sTbHead.indexOf("X-Account-Key") < 0) {


### PR DESCRIPTION
Pattern "." does not match line breaks (\r and \n) even when option "m" is set in JavaScript.
If you want to match a regexp pattern to line breaks, you can use "[\s\S]".
